### PR TITLE
Fix for older Docker (e.g. 1.7)

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
@@ -41,11 +41,16 @@ public class DockerContainer implements Closeable {
     public void assertRunning() {
         try {
             JsonNode state = inspect().get("State");
-            if ((state.get("Status") == null && state.get("Running") == null)
-                || (state.get("Status") != null && !"running".equals(state.get("Status").asText()))
-                || (state.get("Running") != null && !"true".equals(state.get("Running").asText()))) {
-                throw new Error("The container is not running: " + state.toString());
+
+            if (state.get("Status") != null && "running".equals(state.get("Status").asText())) {
+                return;
             }
+
+            if (state.get("Running") != null && "true".equals(state.get("Running").asText())) {
+                return;
+            }
+
+            throw new Error("The container is not running: " + state.toString());
         } catch (IOException e) {
             throw new Error("The container is not running", e);
         }

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
@@ -41,7 +41,9 @@ public class DockerContainer implements Closeable {
     public void assertRunning() {
         try {
             JsonNode state = inspect().get("State");
-            if (!"running".equals(state.get("Status").asText())) {
+            if ((state.get("Status") == null && state.get("Running") == null)
+                || (state.get("Status") != null && !"running".equals(state.get("Status").asText()))
+                || (state.get("Running") != null && !"true".equals(state.get("Running").asText()))) {
                 throw new Error("The container is not running: " + state.toString());
             }
         } catch (IOException e) {


### PR DESCRIPTION
It looks older Docker reports status differently. When a new way isn't found (NPE can occur), fallback to legacy mode is used.