### PR TITLE
[JENKINS-43189] Add the git executable to the JavaContainer for ATH tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-target
+target/
+
+*.iml
+.idea/

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
@@ -10,4 +10,4 @@ RUN echo deb http://archive.ubuntu.com/ubuntu precise universe >> /etc/apt/sourc
 RUN apt-get update -y && apt-get install --no-install-recommends -y software-properties-common
 RUN add-apt-repository ppa:openjdk-r/ppa
 RUN apt-get update
-RUN apt-get install --no-install-recommends -y openjdk-8-jdk openjdk-7-jdk curl wget ant maven
+RUN apt-get install --no-install-recommends -y openjdk-8-jdk openjdk-7-jdk curl wget ant maven git


### PR DESCRIPTION
[JENKINS-43189](https://issues.jenkins-ci.org/browse/JENKINS-43189) Add the git executable to the JavaContainer for ATH tests using Java and Git