### PR TITLE
apt picks the wrong versions of dependencies when something newer is available

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
@@ -5,11 +5,12 @@
 # cf. SshdContainer/Dockerfile
 FROM jenkins/sshd:ff2527313f5c
 
+ENV JDK_VERSION 8u144-b01-2
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         software-properties-common=0.96.24.17 \
-        openjdk-8-jdk=8u144-b01-2 \
+        openjdk-8-jre-headless=$JDK_VERSION \
+        openjdk-8-jdk-headless=$JDK_VERSION \
         curl=7.55.1-1ubuntu2.1 \
-        wget=1.19.1-3ubuntu1.1 \
         ant=1.9.9-4 \
         maven=3.5.0-6


### PR DESCRIPTION
Fixes a problem in #9 apparent only after an update appeared on the repository.

@reviewbybees