### PR TITLE
[JENKINS-48310] [docker-fixtures] Docker for JavaContainer does not build

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
@@ -11,6 +11,6 @@ RUN apt-get update && \
         software-properties-common=0.96.24.17 \
         openjdk-8-jre-headless=$JDK_VERSION \
         openjdk-8-jdk-headless=$JDK_VERSION \
-        curl=7.55.1-1ubuntu2.1 \
+        curl=7.55.1-1ubuntu2.2 \
         ant=1.9.9-4 \
         maven=3.5.0-6


### PR DESCRIPTION
See [JENKINS-48310](https://issues.jenkins-ci.org/browse/JENKINS-48310)

Package curl:7.55.1-1ubuntu2.1 is not longer available ([Details](https://packages.ubuntu.com/search?keywords=curl&searchon=names&suite=artful&section=all)) because of a vulnerability.

@reviewbybees esp. @jglick 