### PR TITLE
Forget about docker-workflow; try to run tests in a way that will let JavaContainerTest not be skipped

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,11 +3,13 @@ pipeline {
         buildDiscarder(logRotator(numToKeepStr: '20'))
         timeout(time: 1, unit: 'HOURS')
     }
+    // cf. https://github.com/jenkins-infra/documentation/blob/master/ci.adoc
     agent {
-        docker {
-            image 'maven:3.5.0-jdk-8'
-            label 'docker'
-        }
+        label 'docker'
+    }
+    tools {
+        jdk 'jdk8'
+        maven 'mvn'
     }
     stages {
         stage('main') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     stages {
         stage('main') {
             steps {
-                sh 'mvn -B clean verify'
+                sh 'mvn -B clean verify -Dmaven.test.failure.ignore'
             }
             post {
                 success {

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -94,6 +94,8 @@ public class Docker {
         return build(image, dir, null);
     }
 
+    public static boolean NO_CACHE;
+
     /**
      * Builds a docker image.
      *
@@ -113,6 +115,9 @@ public class Docker {
             processBuilder.redirectOutput(ProcessBuilder.Redirect.appendTo(log));
         } else {
             processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        }
+        if (NO_CACHE) {
+            buildCmd.add("--no-cache=true");
         }
 
         StringBuilder sb = new StringBuilder("Building Docker image `").append(buildCmd.toString()).append("`");

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
@@ -3,7 +3,7 @@
 #
 
 # cf. SshdContainer/Dockerfile
-FROM jenkins/sshd:ff2527313f5c
+FROM jenkins/sshd:5fed1a40e5de
 
 ENV JDK_VERSION 8u144-b01-2
 RUN apt-get update && \

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer/Dockerfile
@@ -7,7 +7,7 @@ FROM ubuntu:artful-20171019
 # install SSHD
 RUN apt-get update -y && \
     apt-get install -y \
-        openssh-server=1:7.5p1-10
+        openssh-server=1:7.5p1-10ubuntu0.1
 RUN mkdir -p /var/run/sshd
 
 # create a test user

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainerTest.java
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-package org.jenkinsci.test.acceptance.docker;
+package org.jenkinsci.test.acceptance.docker.fixtures;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,13 +30,15 @@ import java.util.List;
 import java.util.Scanner;
 import org.apache.commons.io.IOUtils;
 import static org.hamcrest.CoreMatchers.*;
-import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
+import org.jenkinsci.test.acceptance.docker.Docker;
+import org.jenkinsci.test.acceptance.docker.DockerRule;
 import org.jenkinsci.utils.process.CommandBuilder;
-import org.junit.Test;
+import org.junit.AfterClass;
 import static org.junit.Assert.*;
 import org.junit.AssumptionViolatedException;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.Test;
 
 public class JavaContainerTest {
 
@@ -68,6 +70,16 @@ public class JavaContainerTest {
             IOUtils.copy(dockerRmi.getInputStream(), System.err);
             dockerRmi.waitFor();
         }
+    }
+
+    @BeforeClass
+    public static void noCache() {
+        Docker.NO_CACHE = true;
+    }
+
+    @AfterClass
+    public static void backToCache() {
+        Docker.NO_CACHE = false;
     }
 
     @Test


### PR DESCRIPTION
Actually checking #14 in CI.

@reviewbybees