### PR TITLE
Remove restricted version of curl.

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
@@ -11,6 +11,6 @@ RUN apt-get update && \
         software-properties-common=0.96.24.17 \
         openjdk-8-jre-headless=$JDK_VERSION \
         openjdk-8-jdk-headless=$JDK_VERSION \
-        curl=7.55.1-1ubuntu2.2 \
+        curl \
         ant=1.9.9-4 \
         maven=3.5.0-6


### PR DESCRIPTION
Hello, again there is problem with availability of particular version. I removed definition of version totally. I do not think that it is necessary having defined which version should be installed, especially in case that such version will not be available forever. Better to let download the last one. 

Jesse is there any reason for definition of versions at all? I believe that the last one should fulfill our needs every time. And in case that it does not and old one is not available, what we can do? Research through other repositories? Would you agree with removing versions?