### PR TITLE
Make Docker.build(Class) (with no File argument) print logs to stdout in case of failure

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -134,7 +134,25 @@ public class Docker {
     }
 
     public DockerImage build(Class<? extends DockerContainer> fixture) throws IOException, InterruptedException {
-        return build(fixture, null);
+        File buildlog = File.createTempFile("docker-" + fixture.getSimpleName() + "-build", ".log");
+        DockerImage image = null;
+        try {
+            image = build(fixture, buildlog);
+        } finally {
+            if (image == null) {
+                dump(buildlog);
+            }
+            buildlog.delete();
+        }
+        return image;
+    }
+
+    static void dump(File log) throws IOException {
+        if (log != null) {
+            System.out.println("---%<--- " + log.getName());
+            FileUtils.copyFile(log, System.out);
+            System.out.println("--->%---");
+        }
     }
 
     public DockerImage build(Class<? extends DockerContainer> fixture, File log) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerRule.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerRule.java
@@ -27,7 +27,6 @@ package org.jenkinsci.test.acceptance.docker;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
-import org.apache.commons.io.FileUtils;
 import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -65,18 +64,7 @@ public final class DockerRule<T extends DockerContainer> implements TestRule {
                 throw new AssumptionViolatedException("Docker is needed locally for the test but is running on " + host);
             }
         }
-        // Adapted from DockerContainerHolder:
-        File buildlog = File.createTempFile("docker-" + type.getSimpleName() + "-build", ".log");
-        DockerImage image = null;
-        try {
-            image = docker.build(type, buildlog);
-        } finally {
-            if (image == null) {
-                dump(buildlog);
-            }
-            buildlog.delete();
-        }
-        return image;
+        return docker.build(type);
     }
 
 
@@ -100,7 +88,7 @@ public final class DockerRule<T extends DockerContainer> implements TestRule {
                 } catch (AssumptionViolatedException e) {
                     throw e;
                 } catch (Throwable t) {
-                    dump(runlog);
+                    Docker.dump(runlog);
                     throw t;
                 } finally {
                     if (runlog != null) {
@@ -115,14 +103,6 @@ public final class DockerRule<T extends DockerContainer> implements TestRule {
                 }
             }
         };
-    }
-
-    private void dump(File log) throws IOException {
-        if (log != null) {
-            System.out.println("---%<--- " + log.getName());
-            FileUtils.copyFile(log, System.out);
-            System.out.println("--->%---");
-        }
     }
 
 }


### PR DESCRIPTION
Will be useful for a planned change to https://github.com/jenkinsci/workflow-api-plugin/pull/67.