### PR TITLE
Configure UTF-8 system locale for SshdContainer and subtypes like JavaContainer

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
@@ -2,10 +2,10 @@
 # Container for running Java processes
 #
 
-# cf. SshdContainer/Dockerfile
-FROM jenkins/sshd:5fed1a40e5de
+# sha1sum ../SshdContainer/Dockerfile | cut -c 1-12
+FROM jenkins/sshd:6c5ecc461e88
 
-ENV JDK_VERSION 8u144-b01-2
+ENV JDK_VERSION 8u162-b12-0ubuntu0.17.10.2
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         software-properties-common=0.96.24.17 \

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer/Dockerfile
@@ -2,12 +2,13 @@
 # Runs sshd and allow the 'test' user to login
 #
 
-FROM ubuntu:artful-20171019
+FROM ubuntu:artful-20180227
 
 # install SSHD
 RUN apt-get update -y && \
     apt-get install -y \
-        openssh-server=1:7.5p1-10ubuntu0.1
+        openssh-server=1:7.5p1-10ubuntu0.1 \
+        locales
 RUN mkdir -p /var/run/sshd
 
 # create a test user
@@ -22,6 +23,12 @@ RUN useradd test -d /home/test && \
 RUN echo "KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1" >> /etc/ssh/sshd_config
 
 RUN echo "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com,hmac-md5,hmac-sha1,hmac-sha1-96,hmac-md5-96" >> /etc/ssh/sshd_config
+
+# https://stackoverflow.com/a/38553499/12916
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
 
 # run SSHD in the foreground with error messages to stderr
 ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e"]

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainerTest.java
@@ -89,4 +89,16 @@ public class JavaContainerTest {
         c.sshWithPublicKey(new CommandBuilder("id"));
     }
 
+    @Test
+    public void locale() throws Exception {
+        JavaContainer c = rule.get();
+        // cf. https://stackoverflow.com/a/4384506/12916
+        assertThat(c.popen(new CommandBuilder("jrunscript", "-e", "'println(java.lang.System.getProperty(\"file.encoding\") + \" vs. \" + java.lang.System.getProperty(\"sun.jnu.encoding\"))'")).verifyOrDieWith("could not run jrunscript"),
+            containsString("UTF-8 vs. UTF-8"));
+        assertThat(c.popen(new CommandBuilder("jrunscript", "-e", "'var f = new java.io.File(\"hello\\u010d\\u0950\"); new java.io.FileOutputStream(f).close(); println(\"name: \" + java.net.URLEncoder.encode(f.name, \"UTF-8\")); println(\"exists: \" + f.file)'")).verifyOrDieWith("could not run jrunscript"),
+            allOf(containsString("exists: true"), containsString("name: hello%C4%8D%E0%A5%90")));
+        assertThat(c.popen(new CommandBuilder("sh", "-c", "'ls | native2ascii -encoding UTF-8'")).verifyOrDieWith("could not run ls"),
+            containsString("hello\\u010d\\u0950"));
+    }
+
 }


### PR DESCRIPTION
I noticed that without this the container runs in ASCII locale, so it is impossible to run tests involving Unicode filename characters.