### PR TITLE
Moving locale from JavaContainerTest to SshdContainerTest

### DIFF
--- a/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainerTest.java
@@ -89,16 +89,4 @@ public class JavaContainerTest {
         c.sshWithPublicKey(new CommandBuilder("id"));
     }
 
-    @Test
-    public void locale() throws Exception {
-        JavaContainer c = rule.get();
-        // cf. https://stackoverflow.com/a/4384506/12916
-        assertThat(c.popen(new CommandBuilder("jrunscript", "-e", "'println(java.lang.System.getProperty(\"file.encoding\") + \" vs. \" + java.lang.System.getProperty(\"sun.jnu.encoding\"))'")).verifyOrDieWith("could not run jrunscript"),
-            containsString("UTF-8 vs. UTF-8"));
-        assertThat(c.popen(new CommandBuilder("jrunscript", "-e", "'var f = new java.io.File(\"hello\\u010d\\u0950\"); new java.io.FileOutputStream(f).close(); println(\"name: \" + java.net.URLEncoder.encode(f.name, \"UTF-8\")); println(\"exists: \" + f.file)'")).verifyOrDieWith("could not run jrunscript"),
-            allOf(containsString("exists: true"), containsString("name: hello%C4%8D%E0%A5%90")));
-        assertThat(c.popen(new CommandBuilder("sh", "-c", "'ls | native2ascii -encoding UTF-8'")).verifyOrDieWith("could not run ls"),
-            containsString("hello\\u010d\\u0950"));
-    }
-
 }

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainerTest.java
@@ -24,21 +24,38 @@
 
 package org.jenkinsci.test.acceptance.docker.fixtures;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import org.jenkinsci.test.acceptance.docker.DockerRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
+import org.jenkinsci.utils.process.CommandBuilder;
 import static org.junit.Assert.assertThat;
 
 public class SshdContainerTest {
 
     @Rule
     public DockerRule<SshdContainer> container = new DockerRule<>(SshdContainer.class);
+    @Rule
+    public DockerRule<JavaContainer> javaContainerRule = new DockerRule<>(JavaContainer.class);
 
     @Test
     public void smokes() throws Exception {
         String version = container.get().ssh().add("echo \"$(id -nu):$(id -ng)\"").popen().verifyOrDieWith("Unable to query test user");
         assertThat(version, containsString("test:test"));
     }
+
+    @Test
+    public void locale() throws Exception {
+        JavaContainer c = javaContainerRule.get();
+        // cf. https://stackoverflow.com/a/4384506/12916
+        assertThat(c.popen(new CommandBuilder("jrunscript", "-e", "'println(java.lang.System.getProperty(\"file.encoding\") + \" vs. \" + java.lang.System.getProperty(\"sun.jnu.encoding\"))'")).verifyOrDieWith("could not run jrunscript"),
+            containsString("UTF-8 vs. UTF-8"));
+        assertThat(c.popen(new CommandBuilder("jrunscript", "-e", "'var f = new java.io.File(\"hello\\u010d\\u0950\"); new java.io.FileOutputStream(f).close(); println(\"name: \" + java.net.URLEncoder.encode(f.name, \"UTF-8\")); println(\"exists: \" + f.file)'")).verifyOrDieWith("could not run jrunscript"),
+            allOf(containsString("exists: true"), containsString("name: hello%C4%8D%E0%A5%90")));
+        assertThat(c.popen(new CommandBuilder("sh", "-c", "'ls | native2ascii -encoding UTF-8'")).verifyOrDieWith("could not run ls"),
+            containsString("hello\\u010d\\u0950"));
+    }
+
 }


### PR DESCRIPTION
Follow-up to #19. I moved the new test because

* the fix was actually in `SshdContainer`, I had just been using its subclass `JavaContainer` for the test since it was convenient to use some JDK commands to exercise scenarios
* `JavaContainerTest.smokes` is written to blow away caches, which is good to do _once_ in a release but it is too expensive to repeat