### PR TITLE
Removing all attempts to pin package versions

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
@@ -3,14 +3,13 @@
 #
 
 # sha1sum ../SshdContainer/Dockerfile | cut -c 1-12
-FROM jenkins/sshd:6c5ecc461e88
+FROM jenkins/sshd:32edfdd58111
 
-ENV JDK_VERSION 8u162-b12-0ubuntu0.17.10.2
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-        software-properties-common=0.96.24.17 \
-        openjdk-8-jre-headless=$JDK_VERSION \
-        openjdk-8-jdk-headless=$JDK_VERSION \
+        software-properties-common \
+        openjdk-8-jre-headless \
+        openjdk-8-jdk-headless \
         curl \
-        ant=1.9.9-4 \
-        maven=3.5.0-6
+        ant \
+        maven

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer/Dockerfile
@@ -2,12 +2,12 @@
 # Runs sshd and allow the 'test' user to login
 #
 
-FROM ubuntu:artful-20180227
+FROM ubuntu:bionic
 
 # install SSHD
 RUN apt-get update -y && \
     apt-get install -y \
-        openssh-server=1:7.5p1-10ubuntu0.1 \
+        openssh-server \
         locales
 RUN mkdir -p /var/run/sshd
 
@@ -19,10 +19,6 @@ RUN useradd test -d /home/test && \
     chown -R test:test /home/test && \
     chmod 0600 /home/test/.ssh/authorized_keys && \
     echo "test:test" | chpasswd
-
-RUN echo "KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1" >> /etc/ssh/sshd_config
-
-RUN echo "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com,hmac-md5,hmac-sha1,hmac-sha1-96,hmac-md5-96" >> /etc/ssh/sshd_config
 
 # https://stackoverflow.com/a/38553499/12916
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \


### PR DESCRIPTION
Has caused too many headaches—Ubuntu package repositories delete artifacts after security repositories. Most recently [here](https://ci.jenkins.io/job/Plugins/job/artifact-manager-s3-plugin/job/PR-20/2/testReport/io.jenkins.plugins.artifact_manager_s3/JCloudsArtifactManagerTest/io_jenkins_plugins_artifact_manager_s3_JCloudsArtifactManagerTest/):

```
Version '8u162-b12-0ubuntu0.17.10.2' for 'openjdk-8-jre-headless' was not found
```

At least using Ubuntu, it just does not seem possible to have reproducible Docker builds.

In the long term, probably the build-from-`Dockerfile` aspect of library should be deprecated in favor of images published to Hub.