### PR TITLE
Properly initialize Docker class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,12 +71,6 @@
             <version>2.2.3</version>
         </dependency>
         <dependency>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-            <version>4.0</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>2.0.3</version>

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -1,25 +1,21 @@
 package org.jenkinsci.test.acceptance.docker;
 
-import com.google.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.utils.process.CommandBuilder;
 import org.jvnet.hudson.annotation_indexer.Index;
 
 import javax.annotation.CheckForNull;
-import javax.inject.Named;
-import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-
 
 /**
  * Entry point to the docker support.
@@ -29,23 +25,16 @@ import java.util.jar.JarFile;
  * @author Kohsuke Kawaguchi
  * @author asotobueno
  */
-@Singleton
 public class Docker {
 
     /**
      * Command to invoke docker.
      */
-    @Inject(optional = true)
-    @Named("docker")
-    private static String stringDockerCmd = "docker";
+    private static final List<String> dockerCmd = Collections.singletonList("docker");
 
-    private static List<String> dockerCmd;// = Arrays.asList("docker");
-
-    @Inject(optional = true)
     public ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 
     public Docker() {
-        dockerCmd = Arrays.asList(stringDockerCmd);
     }
 
     public static CommandBuilder cmd(String... cmd) {


### PR DESCRIPTION
Using `Docker.cmd` was launching native process without leading `docker` in case the instance was not injected first somewhere. IOW, the class needs to be instantiated before its static methods' invariants can be satisfied.

Avoiding this bestiality. I am not aware of the code that takes advantage of the ability to replace the command, but we can re-add that once the need surfaces.