### PR TITLE
DockerContainer.close should be idempotent

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
@@ -159,13 +159,14 @@ public class DockerContainer implements Closeable {
      */
     public void close() {
         try {
-            p.destroy();
-            // If container fail to start, this produces phone failure that presents container to be removed
-            int killStatus = Docker.cmd("kill").add(cid).build().start().waitFor();
-            Docker.cmd("rm").add(cid)
-                    .popen().verifyOrDieWith("Failed to rm " + cid + ". kill completed with " + killStatus);
             if (shutdownHook != null) {
+                p.destroy();
+                // If container fail to start, this produces phone failure that presents container to be removed
+                int killStatus = Docker.cmd("kill").add(cid).build().start().waitFor();
+                Docker.cmd("rm").add(cid)
+                    .popen().verifyOrDieWith("Failed to rm " + cid + ". kill completed with " + killStatus);
                 Runtime.getRuntime().removeShutdownHook(shutdownHook);
+                shutdownHook = null;
             }
         } catch (IOException | InterruptedException e) {
             throw new AssertionError("Failed to close down docker container " + cid, e);


### PR DESCRIPTION
Discovered by @varyvol and tracked down in https://github.com/jenkinsci/mercurial-plugin/pull/135. Seemed that when you use `surefire.rerunFailingTestsCount` > 0 with `DockerClassRule`, if the test failed then `close` would get called twice on a single container, making the test throw a spurious error.