### PR TITLE
Basic support for custom networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ When the test case finishes, the container is stopped and cleaned up automatical
 When you specify `ports` in the annotation, you allow services in the fixture to be accessed from the test.
 Always use the `ipBound` and `port` methods on each container to determine where to make the actual connection.
 
+## Custom networks
+If you want your docker containers to connect to a custom network you can set the environment variable `DOCKER_FIXTURES_NETWORK` to the name of the network you want to use.
+
 ## Example
 
 See the `mercurial-plugin` sources for a complete example of defining and using a fixture, including inheritance:

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerContainer.java
@@ -214,6 +214,9 @@ public class DockerContainer implements Closeable {
      * IP address of this container reachable through the bridge.
      */
     public String getIpAddress() throws IOException {
+        if (System.getenv("DOCKER_FIXTURES_NETWORK") != null) {
+            return inspect().get("NetworkSettings").get("Networks").get(System.getenv("DOCKER_FIXTURES_NETWORK")).get("IPAddress").asText();
+        }
         return inspect().get("NetworkSettings").get("IPAddress").asText();
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -78,6 +78,9 @@ public class DockerImage {
     private <T extends DockerContainer> T start(Starter starter, Class<T> type) throws InterruptedException, IOException {
         CommandBuilder docker = Docker.cmd("run");
         docker.add("-d");
+        if (starter.network != null) {
+            docker.add("--network", starter.network);
+        }
         for (int p : starter.ports) {
             docker.add("-p", starter.getPortMapping(p));
         }
@@ -188,6 +191,7 @@ public class DockerImage {
         private int[] ports;
         private int[] udpPorts;
         private File log;
+        private String network;
 
         public Starter(Class<T> type, DockerImage image) {
             this.type = type;
@@ -199,6 +203,7 @@ public class DockerImage {
             if (fixtureAnnotation.matchHostPorts()) {
                 portOffset = 0;
             }
+            network = System.getenv("DOCKER_FIXTURES_NETWORK");
         }
 
         public /*@Nonnull*/ Starter<T> withPorts(int... ports) {


### PR DESCRIPTION
This change adds limited support for custom networks in docker-fixtures, allowing for example to launch the ATH with a docker compose file like this one:

```
version: '3'
services:
  firefox:
    image: '${SELENIUM_CONTAINER}:${SELENIUM_CONTAINER_VERSION}'
    networks:
      - ath-network
    ports:
      - '5900:5900'
      - '4444:4444'
    container_name: firefox
    environment:
      - SCREEN_WIDTH:1680
      - SCREEN_HEIGHT:1090
  mvn:
    container_name: mvn
    networks:
      - ath-network
    shm_size: '2gb'
    image: '${MAVEN_CONTAINER}:${MAVEN_CONTAINER_VERSION}'
    ports:
      - '5005:5005'
    working_dir: /src
    command: >
      bash -c "mvn test ${MAVEN_ARGS}"
    volumes:
      - ./pom.xml:/src/pom.xml
      - ./src:/src/src
      - ./.mvn:/src/.mvn
      - ./config.groovy:/src/config.groovy
      - ${WAR_FILE}:/src/jenkins.war
      - ${MAVEN_EXCLUDES_FILE}:${EXCLUDES_DESTINATION}
      - /var/run/docker.sock:/var/run/docker.sock
      - ${MAVEN_FOLDER}:/root/.m2
      - ${MAVEN_SETTINGS_FILE}:${CUSTOM_SETTINGS_DESTINATION}
    environment:
      - DISPLAY=:0
      - RECORDER=off
      - BROWSER=remote-webdriver-firefox
      - REMOTE_WEBDRIVER_URL=http://firefox:4444/wd/hub
      - JENKINS_LOCAL_HOSTNAME=mvn
      - CONFIG=config.groovy
      - MAVEN_OPTS=-Xmx512m -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XshowSettings:vm
      - SHARED_DOCKER_SERVICE=true
      - DOCKER_FIXTURES_NETWORK=ath-network
    depends_on:
      - firefox
networks:
  ath-network:
    name: ath-network
    attachable: true
```
 
Compose file ~~copied~~ inspired by @jglick work :trollface: 

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
