### PR TITLE
Align jackson-databind version with io.jenkins.configuration-as-code:test-harness:1.54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.7</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Align the `jackson-databind` version with the one in `io.jenkins.configuration-as-code:test-harness:1.54` so a Maven enforcer rule `requireUpperBoundDeps` can be used.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
