### PR TITLE
Update docker fixtures for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>jenkins</artifactId>
-        <version>1.54</version>
+        <version>1.76</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.test</groupId>
@@ -51,14 +51,13 @@
     </build>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.level>8</java.level>
-        <findbugs.failOnError>false</findbugs.failOnError> <!-- TODO -->
+        <spotbugs.failOnError>false</spotbugs.failOnError> <!-- TODO -->
     </properties>
     <dependencies>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
@@ -68,12 +67,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.0</version>
+            <version>2.13.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>annotation-indexer</artifactId>
-            <version>1.9</version>
+            <version>1.16</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -84,12 +83,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-depchain</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.6</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
@@ -8,8 +8,7 @@ FROM jenkins/sshd:32edfdd58111
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         software-properties-common \
-        openjdk-8-jre-headless \
-        openjdk-8-jdk-headless \
+        openjdk-11-jdk-headless \
         curl \
         ant \
         maven

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainerTest.java
@@ -85,7 +85,7 @@ public class JavaContainerTest {
     @Test
     public void smokes() throws Exception {
         JavaContainer c = rule.get();
-        assertThat(c.popen(new CommandBuilder("java", "-version")).verifyOrDieWith("could not launch Java"), containsString("openjdk version \"1.8.0_"));
+        assertThat(c.popen(new CommandBuilder("java", "-version")).verifyOrDieWith("could not launch Java"), containsString("openjdk version \"11"));
         c.sshWithPublicKey(new CommandBuilder("id"));
     }
 

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainerTest.java
@@ -26,12 +26,13 @@ package org.jenkinsci.test.acceptance.docker.fixtures;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.jenkinsci.test.acceptance.docker.DockerRule;
 import org.junit.Rule;
 import org.junit.Test;
 
 import org.jenkinsci.utils.process.CommandBuilder;
-import static org.junit.Assert.assertThat;
 
 public class SshdContainerTest {
 
@@ -50,12 +51,10 @@ public class SshdContainerTest {
     public void locale() throws Exception {
         JavaContainer c = javaContainerRule.get();
         // cf. https://stackoverflow.com/a/4384506/12916
-        assertThat(c.popen(new CommandBuilder("jrunscript", "-e", "'println(java.lang.System.getProperty(\"file.encoding\") + \" vs. \" + java.lang.System.getProperty(\"sun.jnu.encoding\"))'")).verifyOrDieWith("could not run jrunscript"),
+        assertThat(c.popen(new CommandBuilder("echo", "'System.out.println(System.getProperty(\"file.encoding\") + \" vs. \" + System.getProperty(\"sun.jnu.encoding\"))'", "| jshell -")).verifyOrDieWith("could not run jshell"),
             containsString("UTF-8 vs. UTF-8"));
-        assertThat(c.popen(new CommandBuilder("jrunscript", "-e", "'var f = new java.io.File(\"hello\\u010d\\u0950\"); new java.io.FileOutputStream(f).close(); println(\"name: \" + java.net.URLEncoder.encode(f.name, \"UTF-8\")); println(\"exists: \" + f.file)'")).verifyOrDieWith("could not run jrunscript"),
+        assertThat(c.popen(new CommandBuilder("echo", "'var f = new java.io.File(\"hello\\u010d\\u0950\"); new java.io.FileOutputStream(f).close(); System.out.println(\"name: \" + java.net.URLEncoder.encode(f.getName(), \"UTF-8\")); System.out.println(\"exists: \" + f.exists())'", "| jshell -")).verifyOrDieWith("could not run jshell"),
             allOf(containsString("exists: true"), containsString("name: hello%C4%8D%E0%A5%90")));
-        assertThat(c.popen(new CommandBuilder("sh", "-c", "'ls | native2ascii -encoding UTF-8'")).verifyOrDieWith("could not run ls"),
-            containsString("hello\\u010d\\u0950"));
     }
 
 }


### PR DESCRIPTION
ATH is failing on recent core

see https://github.com/jenkinsci/acceptance-test-harness/issues/807