### PR TITLE
Make docker-fixtures work on Java 17 and update commons-lang to 3.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,26 +1,5 @@
-pipeline {
-    options {
-        buildDiscarder(logRotator(numToKeepStr: '20'))
-        timeout(time: 1, unit: 'HOURS')
-    }
-    // cf. https://github.com/jenkins-infra/documentation/blob/master/ci.adoc
-    agent {
-        label 'docker'
-    }
-    tools {
-        jdk 'jdk8'
-        maven 'mvn'
-    }
-    stages {
-        stage('main') {
-            steps {
-                sh 'mvn -B clean verify -Dmaven.test.failure.ignore'
-            }
-            post {
-                success {
-                    junit '**/target/surefire-reports/TEST-*.xml'
-                }
-            }
-        }
-    }
-}
+buildPlugin(useContainerAgent: true, configurations: [
+    [platform: 'linux', jdk: '8'],
+    [platform: 'linux', jdk: '11'],
+    [platform: 'linux', jdk: '17']
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>jenkins</artifactId>
-        <version>1.76</version>
+        <version>1.88</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.test</groupId>
@@ -31,8 +31,8 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/docker-fixtures.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/docker-fixtures.git</developerConnection>
+        <connection>scm:git:https://github.com/jenkinsci/docker-fixtures.git</connection>
+        <developerConnection>scm:git:git://git@github.com/jenkinsci/docker-fixtures.git</developerConnection>
         <url>https://github.com/jenkinsci/docker-fixtures</url>
         <tag>HEAD</tag>
     </scm>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.3</version>
+            <version>2.13.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
@@ -76,9 +76,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -93,8 +93,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>4.8.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.test.acceptance.docker;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.jenkinsci.utils.process.CommandBuilder;
 
 import java.io.File;

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.test.acceptance.docker.fixtures;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.jenkinsci.test.acceptance.docker.DockerContainer;
 import org.jenkinsci.test.acceptance.docker.DockerFixture;
 import org.jenkinsci.utils.process.CommandBuilder;

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/DockerImageTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/DockerImageTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DockerImageTest {


### PR DESCRIPTION
Currently, still needed for the ATH, until we use testcontainers or something.
The change proposed ensures docker-fixtures build on Java 17 onwards too, I went ahead and updated commons-lang to 3.x while I was at it.

Closes https://github.com/jenkinsci/docker-fixtures/pull/40

cc @jglick if you mind taking a look :)

