### PR TITLE
force to use only the key passed as parameter (user with many keys can have Too many authentication failures) and do not use local ~/.ssh/config as it may contains some rules

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/fixtures/SshdContainer.java
@@ -76,7 +76,7 @@ public class SshdContainer extends DockerContainer {
      */
     public CommandBuilder ssh() {
         return new CommandBuilder("ssh")
-                .add("-p", port(22), "-o", "StrictHostKeyChecking=no", "-i", getPrivateKey(), "test@" + ipBound(22));
+                .add("-p", port(22), "-F", "none", "-o", "IdentitiesOnly=yes", "-o", "StrictHostKeyChecking=no", "-i", getPrivateKey(), "test@" + ipBound(22));
         // TODO as in CLITest.tempHome this would better use a custom home directory so any existing ~/.ssh/known_hosts is ignored
     }
 


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
