### PR TITLE
Add `DockerExtension` to support `DockerContainer` for JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,16 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.13.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.13.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-depchain</artifactId>
             <version>1.2.6</version>

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -69,7 +69,7 @@ public class Docker {
             return psOutput.contains(container);
         }
         // docker command errored - and it does not do this if there is no match.
-        System.err.println("docker ps failed with code: " + pExit + 
+        System.err.println("docker ps failed with code: " + pExit +
                           (psOutput != null ? " and output: " + psOutput : " and provided no output"));
         return false;
     }
@@ -138,7 +138,7 @@ public class Docker {
         return image;
     }
 
-    static void dump(File log) throws IOException {
+    public static void dump(File log) throws IOException {
         if (log != null) {
             System.out.println("---%<--- " + log.getName());
             FileUtils.copyFile(log, System.out);

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/junit/jupiter/DockerExtension.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/junit/jupiter/DockerExtension.java
@@ -1,0 +1,175 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.test.acceptance.docker.junit.jupiter;
+
+import org.jenkinsci.test.acceptance.docker.Docker;
+import org.jenkinsci.test.acceptance.docker.DockerClassRule;
+import org.jenkinsci.test.acceptance.docker.DockerContainer;
+import org.jenkinsci.test.acceptance.docker.DockerImage;
+import org.jenkinsci.test.acceptance.docker.DockerRule;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.opentest4j.TestAbortedException;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+
+/**
+ * Provides a given {@link DockerContainer} for JUnit5 tests.
+ * <p>
+ * When registered as a {@code static} variable, the underlying container is started before all tests and stopped once all tests concluded.
+ * <pre>{@code
+ * @RegisterExtension
+ * private static final DockerExtension<JavaContainer> container = new DockerExtension(JavaContainer.class);
+ * }</pre>
+ * When registered as an {@code instance} variable, the underlying container is started / stopped before / after each test.
+ * <pre>{@code
+ * @RegisterExtension
+ * private final DockerExtension<JavaContainer> container = new DockerExtension(JavaContainer.class);
+ * }</pre>
+ * <p>
+ * This is the JUnit5 implementation of {@link DockerRule} and {@link DockerClassRule}.
+ *
+ * @see DockerContainer
+ * @see DockerRule
+ * @see DockerClassRule
+ */
+public final class DockerExtension<T extends DockerContainer>
+        implements BeforeAllCallback, BeforeEachCallback, InvocationInterceptor, AfterAllCallback, AfterEachCallback {
+
+    final Class<T> type;
+    private boolean localOnly;
+    private T container;
+    private File runlog;
+
+    private boolean isNonStatic = false;
+
+    /**
+     * Construct an instance of the extension for the given {@link DockerContainer} type.
+     *
+     * @param type the {@link DockerContainer} class
+     */
+    public DockerExtension(Class<T> type) {
+        this.type = type;
+    }
+
+    /**
+     * Enforce that the docker host must be local.
+     *
+     * @return this
+     */
+    public DockerExtension<T> localOnly() {
+        localOnly = true;
+        return this;
+    }
+
+    /**
+     * Returns the {@link DockerContainer} managed by this extension.
+     *
+     * @return the {@link DockerContainer} managed by this extension.
+     */
+    public T get() {
+        if (container == null) {
+            throw new IllegalStateException("Container was not initialized - make sure to register it via @RegisterExtension");
+        }
+        return container;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        start();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        if (container == null) {
+            isNonStatic = true;
+            start();
+        }
+    }
+
+    @Override
+    public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        try {
+            invocation.proceed();
+        } catch (TestAbortedException e) {
+            throw e;
+        } catch (Throwable t) {
+            Docker.dump(runlog);
+            throw t;
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        stop();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        if (isNonStatic) {
+            stop();
+        }
+    }
+
+    private void start() throws Exception {
+        if (container == null) {
+            // Adapted from WithDocker:
+            Docker docker = new Docker();
+            if (!docker.isAvailable()) {
+                throw new TestAbortedException("Docker is needed for the test");
+            }
+            if (localOnly) {
+                String host = DockerImage.getDockerHost();
+                if (!InetAddress.getByName(host).isLoopbackAddress()) {
+                    throw new TestAbortedException("Docker is needed locally for the test but is running on " + host);
+                }
+            }
+
+            DockerImage image = docker.build(type);
+            runlog = File.createTempFile("docker-" + type.getSimpleName() + "-run", ".log");
+            container = image.start(type).withLog(runlog).start();
+        }
+    }
+
+    private void stop() {
+        if (runlog != null) {
+            runlog.delete();
+            runlog = null;
+        }
+        // From DockerContainerHolder:
+        if (container != null) {
+            container.close();
+            container = null;
+        }
+    }
+
+}

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/junit/jupiter/JavaContainerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/junit/jupiter/JavaContainerTest.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.test.acceptance.docker.fixtures.junit.jupiter;
+
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.test.acceptance.docker.Docker;
+import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
+import org.jenkinsci.test.acceptance.docker.junit.jupiter.DockerExtension;
+import org.jenkinsci.utils.process.CommandBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opentest4j.TestAbortedException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class JavaContainerTest {
+
+    @RegisterExtension
+    private static final DockerExtension<JavaContainer> CONTAINER = new DockerExtension<>(JavaContainer.class);
+
+    @BeforeAll
+    static void cleanOldImages() throws Exception {
+        Process dockerImages;
+        try {
+            dockerImages = new ProcessBuilder("docker", "images", "--format", "{{.Repository}}:{{.Tag}}").start();
+        } catch (IOException x) {
+            throw new TestAbortedException("could not run docker", x);
+        }
+        Scanner scanner = new Scanner(dockerImages.getInputStream());
+        List<String> toRemove = new ArrayList<>();
+        while (scanner.hasNext()) {
+            String image = scanner.next();
+            if (image.startsWith("jenkins/")) {
+                toRemove.add(image);
+            }
+        }
+        dockerImages.waitFor();
+        if (!toRemove.isEmpty()) {
+            toRemove.add(0, "docker");
+            toRemove.add(1, "rmi");
+            Process dockerRmi = new ProcessBuilder(toRemove).redirectErrorStream(true).start();
+            // Cannot use inheritIO from Surefire.
+            IOUtils.copy(dockerRmi.getInputStream(), System.err);
+            dockerRmi.waitFor();
+        }
+    }
+
+    @BeforeAll
+    static void noCache() {
+        Docker.NO_CACHE = true;
+    }
+
+    @AfterAll
+    static void backToCache() {
+        Docker.NO_CACHE = false;
+    }
+
+    @Test
+    void smokes() throws Exception {
+        JavaContainer c = CONTAINER.get();
+        assertThat(c.popen(new CommandBuilder("java", "-version")).verifyOrDieWith("could not launch Java"), containsString("openjdk version \"17"));
+        c.sshWithPublicKey(new CommandBuilder("id"));
+    }
+
+}

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/junit/jupiter/SshdContainerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/junit/jupiter/SshdContainerTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.test.acceptance.docker.fixtures.junit.jupiter;
+
+import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
+import org.jenkinsci.test.acceptance.docker.fixtures.SshdContainer;
+import org.jenkinsci.test.acceptance.docker.junit.jupiter.DockerExtension;
+import org.jenkinsci.utils.process.CommandBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class SshdContainerTest {
+
+    @RegisterExtension
+    private static final DockerExtension<SshdContainer> SSHD_CONTAINER = new DockerExtension<>(SshdContainer.class);
+    @RegisterExtension
+    private static final DockerExtension<JavaContainer> JAVA_CONTAINER = new DockerExtension<>(JavaContainer.class);
+
+    @Test
+    void smokes() throws Exception {
+        String version = SSHD_CONTAINER.get().ssh().add("echo \"$(id -nu):$(id -ng)\"").popen().verifyOrDieWith("Unable to query test user");
+        assertThat(version, containsString("test:test"));
+    }
+
+    @Test
+    void locale() throws Exception {
+        JavaContainer c = JAVA_CONTAINER.get();
+        // cf. https://stackoverflow.com/a/4384506/12916
+        assertThat(c.popen(new CommandBuilder("echo", "'System.out.println(System.getProperty(\"file.encoding\") + \" vs. \" + System.getProperty(\"sun.jnu.encoding\"))'", "| jshell -")).verifyOrDieWith("could not run jshell"),
+                containsString("UTF-8 vs. UTF-8"));
+        assertThat(c.popen(new CommandBuilder("echo", "'var f = new java.io.File(\"hello\\u010d\\u0950\"); new java.io.FileOutputStream(f).close(); System.out.println(\"name: \" + java.net.URLEncoder.encode(f.getName(), \"UTF-8\")); System.out.println(\"exists: \" + f.exists())'", "| jshell -")).verifyOrDieWith("could not run jshell"),
+                allOf(containsString("exists: true"), containsString("name: hello%C4%8D%E0%A5%90")));
+    }
+
+}

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/junit/jupiter/DockerExtensionTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/junit/jupiter/DockerExtensionTest.java
@@ -1,0 +1,79 @@
+package org.jenkinsci.test.acceptance.docker.junit.jupiter;
+
+import org.jenkinsci.test.acceptance.docker.DockerContainer;
+import org.jenkinsci.test.acceptance.docker.DockerFixture;
+import org.jenkinsci.test.acceptance.docker.fixtures.SshdContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+class DockerExtensionTest {
+
+    @RegisterExtension
+    private static final DockerExtension<SshdContainer> STATIC_EXTENSION = new DockerExtension<>(SshdContainer.class);
+
+    @RegisterExtension
+    private static final DockerExtension<CustomContainer> CUSTOM_EXTENSION = new DockerExtension<>(CustomContainer.class);
+
+    @RegisterExtension
+    private final DockerExtension<SshdContainer> instanceExtension = new DockerExtension<>(SshdContainer.class);
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        STATIC_EXTENSION.get().assertRunning();
+        // instanceExtension.get().assertRunning();
+        CUSTOM_EXTENSION.get().assertRunning();
+    }
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        STATIC_EXTENSION.get().assertRunning();
+        instanceExtension.get().assertRunning();
+        CUSTOM_EXTENSION.get().assertRunning();
+    }
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        STATIC_EXTENSION.get().assertRunning();
+        // instanceExtension.get().assertRunning();
+        CUSTOM_EXTENSION.get().assertRunning();
+    }
+
+    @AfterEach
+    void afterEach() throws Exception {
+        STATIC_EXTENSION.get().assertRunning();
+        instanceExtension.get().assertRunning();
+        CUSTOM_EXTENSION.get().assertRunning();
+    }
+
+    @Test
+    void testContainers() throws Exception {
+        STATIC_EXTENSION.get().assertRunning();
+        // instanceExtension.get().assertRunning();
+        CUSTOM_EXTENSION.get().assertRunning();
+    }
+
+    @Test
+    @Disabled("Used to manually check behavior of DockerExtension#interceptTestMethod")
+    void testAssumption() {
+        assumeFalse(true, "Test is skipped");
+    }
+
+    @Test
+    @Disabled("Used to manually check behavior of DockerExtension#interceptTestMethod")
+    void testFailure() {
+        assertTrue(false, "Test fails");
+    }
+
+    @DockerFixture(id = "custom", ports = 8080)
+    public static class CustomContainer extends DockerContainer {
+
+    }
+}

--- a/src/test/resources/org/jenkinsci/test/acceptance/docker/junit/jupiter/DockerExtensionTest/CustomContainer/Dockerfile
+++ b/src/test/resources/org/jenkinsci/test/acceptance/docker/junit/jupiter/DockerExtensionTest/CustomContainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM eclipse-temurin:21-jre
+ENTRYPOINT ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
Adds a JUnit 5-compatible `Extension` that provides similar capabilities as `DockerRule` and `DockerClassRule`.

The main difference from the JUnit 4 counterparts is that the `Extension` will not only build the images, but also start them during the `beforeEach` or `beforeAll` phase, as opposed to starting them on-demand. While it would be possible to provide that on-demand capability, I personally do not see the reason for it and would argue that it somewhat defeats the purpose of a `Rule/Extension`.

To allow the container to be used _per test_ (like a `Rule`) as well as _per class_ (like a `ClassRule`), the `Extension` can be registered either as a `static` or an `instance` variable.

### Testing done

Added tests to cover the different variants (`static` vs. `instance` registration) of the extension. I also did some manual testing for things that can not really be covered by unit tests.
Copied existing tests for `DockerContainer` implementations to verify these work with JUnit 5.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed