### PR TITLE
Upgrade Java container to 21

### DIFF
--- a/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
+++ b/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainer/Dockerfile
@@ -8,7 +8,7 @@ FROM jenkins/sshd:23e678bc2c56
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         software-properties-common \
-        openjdk-17-jdk-headless \
+        openjdk-21-jdk-headless \
         curl \
         ant \
         maven

--- a/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainerTest.java
+++ b/src/test/java/org/jenkinsci/test/acceptance/docker/fixtures/JavaContainerTest.java
@@ -85,7 +85,7 @@ public class JavaContainerTest {
     @Test
     public void smokes() throws Exception {
         JavaContainer c = rule.get();
-        assertThat(c.popen(new CommandBuilder("java", "-version")).verifyOrDieWith("could not launch Java"), containsString("openjdk version \"17"));
+        assertThat(c.popen(new CommandBuilder("java", "-version")).verifyOrDieWith("could not launch Java"), containsString("openjdk version \"21"));
         c.sshWithPublicKey(new CommandBuilder("id"));
     }
 


### PR DESCRIPTION
When running the ATH for controller compiled with Java 21, test failure for ath test [plugins.SshSlavesPluginTest](https://github.com/jenkinsci/acceptance-test-harness/blob/master/src/test/java/plugins/SshSlavesPluginTest.java) noted The test uses the fixture from this repository, as [linked in there](https://github.com/jenkinsci/acceptance-test-harness/blob/master/src/main/resources/org/jenkinsci/test/acceptance/docker/fixtures/SshAgentContainer/Dockerfile).

Plan to upgrade the Java container version in here, once complete and released, upgrade the dependency in the ATH repository.

### Testing done

CI build to pass, there is existing automated tests for this change.

Also verified manually building the image and running the command as in the automated test.
```
→ docker run --rm -it --entrypoint java jenkins/java:132f41d4b1a9 -version
openjdk version "21.0.9" 2025-10-21
OpenJDK Runtime Environment (build 21.0.9+10-Ubuntu-124.04)
OpenJDK 64-Bit Server VM (build 21.0.9+10-Ubuntu-124.04, mixed mode, sharing)
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
